### PR TITLE
Switch to using a hash function based on the group definition

### DIFF
--- a/draft-ietf-kitten-krb-spake-preauth-04.xml
+++ b/draft-ietf-kitten-krb-spake-preauth-04.xml
@@ -6,8 +6,8 @@
 <!ENTITY rfc6113 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6113.xml">
 <!ENTITY rfc4120 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4120.xml">
 <!ENTITY rfc5226 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5226.xml">
+<!ENTITY rfc6234 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6234.xml">
 <!ENTITY rfc6560 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6560.xml">
-<!ENTITY rfc6649 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6649.xml">
 <!ENTITY rfc7748 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.7748.xml">
 <!ENTITY rfc8032 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.8032.xml">
 <!ENTITY spake SYSTEM "http://xml2rfc.ietf.org/public/rfc/bibxml3/reference.I-D.draft-irtf-cfrg-spake2-01.xml">
@@ -26,7 +26,7 @@
 <?rfc docmapping="yes"?>
 
 <rfc category="std" docName="draft-ietf-kitten-krb-spake-preauth-04"
-      ipr="trust200902" updates="3961">
+      ipr="trust200902">
   <front>
     <title abbrev="SPAKE Pre-Authentication">SPAKE Pre-Authentication</title>
 
@@ -168,7 +168,7 @@
         <t>This mechanism provides its own method of deriving encryption keys
         from the calculated shared secret K, for several reasons: to fit
         within the framework of <xref target="RFC3961"/>, to ensure
-        negotiation integrity using a transcript checksum, to derive different
+        negotiation integrity using a transcript hash, to derive different
         keys for each use, and to bind the KDC-REQ-BODY to the
         pre-authentication exchange.</t>
       </section>
@@ -181,8 +181,8 @@
       target="RFC2119"/>.</t>
       <t>This document refers to numerous terms and protocol messages defined
       in <xref target="RFC4120"/>.</t>
-      <t>The terms "encryption type", "required checksum mechanism", and
-      "get_mic" are defined in <xref target="RFC3961"/>.</t>
+      <t>The terms "encryption type", "key generation seed length", and
+      "random-to-key" are defined in <xref target="RFC3961"/>.</t>
       <t>The terms "FAST", "PA-FX-COOKIE", "KDC_ERR_PREAUTH_EXPIRED",
       "KDC_ERR_MORE_PREAUTH_DATA_REQUIRED", "KDC_ERR_PREAUTH_FAILED",
       "pre-authentication facility", and "authentication set" are defined in
@@ -224,20 +224,6 @@
       </section>
     </section>
 
-    <section title="Update to Checksum Specifications" anchor="cksumupdate">
-      <t><xref target="RFC3961"/> section 4 specifies the Kerberos checksum
-      algorithm profile.  It does not require checksums to be deterministic.
-      In practice, DES-based checksum types (deprecated by <xref
-      target="RFC6649"/>) use a random confounder; all other current checksum
-      types are deterministic.</t>
-      <t>Future checksum types required by an encryption type MUST be
-      deterministic.  All future checksum types SHOULD be deterministic.</t>
-      <t>This mechanism requires a deterministic checksum type for the
-      transcript checksum.  Therefore, a KDC MUST NOT offer this mechanism if
-      the initial reply key is of type des-cbc-crc, des-cbc-md4, or
-      des-cbc-md5.</t>
-    </section>
-
     <section title="SPAKE Pre-Authentication Message Protocol">
       <t>This mechanism uses the reply key and provides the Client
       Authentication and Strengthening Reply Key pre-authentication facilities
@@ -251,8 +237,10 @@
 
       <t>This mechanism negotiates a choice of group for the SPAKE algorithm.
       Groups are defined in the IANA "Kerberos SPAKE Groups" registry created
-      by this document. Clients and KDCs MUST implement the edwards25519
-      group, but MAY choose not to offer or accept it by default.</t>
+      by this document. Each group definition specifies an associated hash
+      function, which will be used for transcript protection and key
+      derivation. Clients and KDCs MUST implement the edwards25519 group, but
+      MAY choose not to offer or accept it by default.</t>
 
       <t>This section will describe the flow of messages when performing SPAKE
       pre-authentication. We will begin by explaining the most verbose version
@@ -311,10 +299,6 @@ SPAKESupport ::= SEQUENCE {
 ]]></artwork>
         </figure>
 
-        <t>The client and KDC initialize a transcript checksum (<xref
-        target="tcksum"/>) and update it with the DER-encoded PA-SPAKE
-        message.</t>
-
         <t>Upon receipt of the support message, the KDC will select a
         group. The KDC SHOULD choose a group from the groups provided by the
         support message. However, if the support message does not contain any
@@ -324,9 +308,7 @@ SPAKESupport ::= SEQUENCE {
 
         <t>Once the KDC has selected a group, the KDC will reply to the client
         with a KDC_ERR_MORE_PREAUTH_DATA_REQUIRED error containing a PA-SPAKE
-        PA-DATA element using the challenge choice. The client and KDC update
-        the transcript checksum with the DER-encoded PA-SPAKE message.</t>
-
+        PA-DATA element using the challenge choice.</t>
         <figure>
           <artwork><![CDATA[
 SPAKEChallenge ::= SEQUENCE {
@@ -365,6 +347,11 @@ SPAKESecondFactor ::= SEQUENCE {
 
         <t>The data field contains optional challenge data. The contents in this
         field will depend upon the second factor type chosen.</t>
+
+        <t>The client and KDC will each initialize a transcript hash (<xref
+        target="transcript"/>) using the hash function associated with the
+        chosen group, and update it with the concatenation of the DER-encoded
+        PA-SPAKE messages sent by the client and the KDC.</t>
       </section>
 
       <section title="Third Pass">
@@ -387,8 +374,8 @@ SPAKEResponse ::= SEQUENCE {
 ]]></artwork>
         </figure>
 
-        <t>The client and KDC will update the transcript checksum with the
-        pubkey value, and use the resulting checksum for all encryption key
+        <t>The client and KDC will update the transcript hash with the pubkey
+        value, and use the resulting hash for all encryption key
         derivations.</t>
 
         <t>The pubkey field indicates the client's public key generated using
@@ -398,7 +385,7 @@ SPAKEResponse ::= SEQUENCE {
         <t>The factor field indicates the client's chosen second factor data.
         The key for this field is K'[1] as specified in <xref
         target="keyderiv"/>. The key usage number for the encryption is
-        KEY_USAGE_SPAKE_FACTOR. The plain text inside the EncryptedData is an
+        KEY_USAGE_SPAKE. The plain text inside the EncryptedData is an
         encoding of SPAKESecondFactor. Once decoded, the SPAKESecondFactor
         contains the type of the second factor and any optional data used. The
         contents of the data field will depend on the second factor type
@@ -417,15 +404,15 @@ SPAKEResponse ::= SEQUENCE {
         KDC MUST reply to the client with KDC_ERR_MORE_PREAUTH_DATA_REQUIRED
         containing a PA-SPAKE PA-DATA element using the encdata choice. The
         key for the EncryptedData value is K'[2] as specified in <xref
-        target="keyderiv"/>, and the key usage number is
-        KEY_USAGE_SPAKE_FACTOR. The plain text of this message contains a
-        DER-encoded SPAKESecondFactor message. As before, the type field of
-        this message will contain the second factor type, and the data field
-        will optionally contain second factor type specific data.</t>
+        target="keyderiv"/>, and the key usage number is KEY_USAGE_SPAKE. The
+        plain text of this message contains a DER-encoded SPAKESecondFactor
+        message. As before, the type field of this message will contain the
+        second factor type, and the data field will optionally contain second
+        factor type specific data.</t>
 
         <figure>
           <artwork><![CDATA[
-KEY_USAGE_SPAKE_FACTOR                  65
+KEY_USAGE_SPAKE                         65
 ]]></artwork>
         </figure>
       </section>
@@ -466,11 +453,13 @@ KEY_USAGE_SPAKE_FACTOR                  65
         KDC optimistically selects a group which the client may not
         support. If the group chosen by the challenge message is supported by
         the client, the client MUST skip to the third pass by issuing an
-        AS-REQ with a PA-SPAKE message using the response choice. If the KDC's
-        chosen group is not supported by the client, the client MUST
-        initialize and update the transcript checksum with the KDC's challenge
-        message, and then continue to the second pass. Clients MUST support
-        this optimization.</t>
+        AS-REQ with a PA-SPAKE message using the response choice. In this case
+        no SPAKESupport message is sent by the client, so the first update to
+        the transcript hash contains only the KDC's optimistic challenge. If
+        the KDC's chosen group is not supported by the client, the client MUST
+        continue to the second pass. In this case both the client and KDC MUST
+        reinitialize the transcript hash for the client's support message.
+        Clients MUST support this optimization.</t>
 
         <t>Second, clients MAY skip the first pass and send an AS-REQ with a
         PA-SPAKE PA-DATA element using the support choice. If the KDC accepts
@@ -503,7 +492,7 @@ KEY_USAGE_SPAKE_FACTOR                  65
         the IANA "Kerberos SPAKE Groups" registry created by this
         document.</t>
         <t>Compose a pepper string by concatenating the string "SPAKEsecret"
-        and the group number as a big-endian four-byte unsigned binary
+        and the group number as a big-endian four-byte two's complement binary
         number.</t>
         <t>Produce an octet string of the required length using PRF+(K,
         pepper), where K is the initial reply key and PRF+ is defined in <xref
@@ -519,42 +508,33 @@ KEY_USAGE_SPAKE_FACTOR                  65
       keys (see <xref target="kdcstate"/>).</t>
     </section>
 
-    <section title="Transcript Checksum" anchor="tcksum">
-      <t>The transcript checksum is an octet string of length equal to the
-      output length of the required checksum type of the encryption type of
-      the initial reply key. The initial value consists of all bits set to
-      zero.</t>
+    <section title="Transcript Hash" anchor="transcript">
+      <t>The transcript hash is an octet string of length equal to the output
+      length of the hash function associated with the selected group. The
+      initial value consists of all bits set to zero.</t>
 
-      <t>When the transcript checksum is updated with an octet string input,
-      the new value is the get_mic result computed over the concatenation of
-      the old value and the input, for the required checksum type of the
-      initial reply key's encryption type, using the initial reply key and the
-      key usage number KEY_USAGE_SPAKE_TRANSCRIPT.</t>
+      <t>When the transcript hash is updated with an octet string input, the
+      new value is the hash function computed over the concatenation of the
+      old value and the input.</t>
 
       <t>In the normal message flow or with the second optimization described
-      in <xref target="optimizations"/>, the transcript checksum is first
-      updated with the client's support message, then the KDC's
-      challenge message, and finally with the client's pubkey value. It
-      therefore incorporates the client's supported groups, the KDC's chosen
-      group, the KDC's initial second-factor messages, and the client and KDC
-      public values. Once the transcript checksum is finalized, it is used
-      without change for all key derivations (<xref target="keyderiv"/>).</t>
+      in <xref target="optimizations"/>, the transcript hash is first updated
+      with the concatenation of the client's support message and the KDC's
+      challenge, and then updated a second time with the client's pubkey
+      value. It therefore incorporates the client's supported groups, the
+      KDC's chosen group, the KDC's initial second-factor messages, and the
+      client and KDC public values. Once the transcript hash is finalized, it
+      is used without change for all key derivations (<xref
+      target="keyderiv"/>).</t>
 
       <t>If the first optimization described in <xref target="optimizations"/>
-      is used successfully, the transcript checksum is updated only with the
-      KDC's challenge message and the client's pubkey value.</t>
+      is used successfully, the transcript hash is updated first with the
+      KDC's challenge message, and second with the client's pubkey value.</t>
 
       <t>If first optimization is used unsuccessfully (i.e. the client does
-      not accept the KDC's selected group), the transcript checksum is updated
-      with the KDC's optimistic challenge message, then with the client's
-      support message, then the KDC's second challenge message, and finally
-      with the client's pubkey value.</t>
-
-      <figure>
-        <artwork><![CDATA[
-KEY_USAGE_SPAKE_TRANSCRIPT              66
-]]></artwork>
-      </figure>
+      not accept the KDC's selected group), the transcript hash is computed as
+      in the normal message flow, without including the KDC's optimistic
+      challenge.</t>
     </section>
 
     <section title="Key Derivation" anchor="keyderiv">
@@ -565,25 +545,35 @@ KEY_USAGE_SPAKE_TRANSCRIPT              66
       slightly from the method used to generate K' in Section 3 of <xref
       target="I-D.irtf-cfrg-spake2">SPAKE</xref>.</t>
 
-      <t>An input string is assembled by concatenating the following values:
+      <t>First, the hash function associated with the selected group is
+      computed over the concatenation of the following values:
       <list style="symbols">
         <t>The fixed string "SPAKEkey".</t>
-        <t>The group number as a big-endian four-byte unsigned binary
+        <t>The group number as a big-endian four-byte two's complement binary
         number.</t>
-        <t>The encryption type of the initial reply key as a
-        big-endian four-byte unsigned binary number.</t>
+        <t>The encryption type of the initial reply key as a big-endian
+        four-byte two's complement binary number.</t>
+        <t>The PRF+ output used to compute the initial secret input w as
+        specified in <xref target="spakeparams"/>.</t>
         <t>The SPAKE result K, converted to an octet string as specified in
         <xref target="spakeparams"/>.</t>
-        <t>The transcript checksum.</t>
+        <t>The transcript hash.</t>
         <t>The KDC-REQ-BODY encoding for the request being sent or responded
         to. Within a FAST channel, the inner KDC-REQ-BODY encoding MUST be
         used.</t>
         <t>The value n as a big-endian four-byte unsigned binary number.</t>
+        <t>A single-byte block counter, with the initial value 0x01.</t>
       </list>
-      The derived key K'[n] has the same encryption type as the initial reply
-      key, and has the value random-to-key(PRF+(initial-reply-key,
-      input-string)). PRF+ is defined in <xref target="RFC6113"/> section
-      5.1.</t>
+      If the hash output is too small for the encryption type's key generation
+      seed length, the block counter value is incremented and the hash
+      function re-computed to produce as many blocks as are required. The
+      result is truncated to the key generation seed length, and the
+      random-to-key function is used to produce an intermediate key with the
+      same encryption type as the initial reply key.</t>
+      <t>The key K'[n] has the same encryption type as the initial reply key,
+      and has the value KRB-FX-CF2(initial-reply-key, intermediate-key,
+      "SPAKE", "keyderiv"), where KRB-FX-CF2 is defined in <xref
+      target="RFC6113"/> section 5.1.</t>
     </section>
 
     <section title="Second Factor Types">
@@ -604,7 +594,7 @@ KEY_USAGE_SPAKE_TRANSCRIPT              66
       <section title="Unauthenticated Plaintext">
         <t>This mechanism includes unauthenticated plaintext in the support and
         challenge messages. Beginning with the third pass, the integrity of
-        this plaintext is ensured by incorporating the transcript checksum into
+        this plaintext is ensured by incorporating the transcript hash into
         the derivation of the final reply key and second factor encryption
         keys. Downgrade attacks on support and challenge messages will result
         in the client and KDC deriving different reply keys and EncryptedData
@@ -667,12 +657,12 @@ KEY_USAGE_SPAKE_TRANSCRIPT              66
 
       <section title="KDC State" anchor="kdcstate">
         <t>A stateless KDC implementation generally must use a PA-FX-COOKIE
-        value to remember its private scalar value x and the transcript
-        checksum. The KDC MUST maintain confidentiality and integrity of the
-        cookie value, perhaps by encrypting it in a key known only to the
-        realm's KDCs. Cookie values may be replayed by attackers. The KDC
-        SHOULD limit the time window of replays using a timestamp, and SHOULD
-        prevent cookie values from being applied to other pre-authentication
+        value to remember its private scalar value x and the transcript hash.
+        The KDC MUST maintain confidentiality and integrity of the cookie
+        value, perhaps by encrypting it in a key known only to the realm's
+        KDCs. Cookie values may be replayed by attackers. The KDC SHOULD limit
+        the time window of replays using a timestamp, and SHOULD prevent
+        cookie values from being applied to other pre-authentication
         mechanisms or other client principals. Within the validity period of a
         cookie, an attacker can replay the final message of a
         pre-authentication exchange to any of the realm's KDCs and make it
@@ -763,8 +753,7 @@ KEY_USAGE_SPAKE_TRANSCRIPT              66
       <t>The following key usage values are assigned for this mechanism:</t>
         <figure>
           <artwork><![CDATA[
-KEY_USAGE_SPAKE_TRANSCRIPT              65
-KEY_USAGE_SPAKE_FACTOR                  66
+KEY_USAGE_SPAKE                         65
 ]]></artwork>
         </figure>
     </section>
@@ -780,10 +769,6 @@ KEY_USAGE_SPAKE_FACTOR                  66
         <c>151</c>
         <c>[this document]</c>
       </texttable>
-
-      <t>The notes for the "Kerberos Checksum Type Numbers" registry should be
-      updated with the following addition: "If the checksum algorithm is
-      non-deterministic, see [this document] <xref target="cksumupdate"/>."</t>
 
       <t>This document establishes two registries with the following
       procedure, in accordance with <xref target="RFC5226"/>:</t>
@@ -887,6 +872,10 @@ KEY_USAGE_SPAKE_FACTOR                  66
               <t hangText="SPAKE N Constant:">
                 The serialized value of the SPAKE N constant in hexadecimal notation.
               </t>
+
+              <t hangText="Hash Function:">
+                The group's associated hash function.
+              </t>
             </list>
           </t>
         </section>
@@ -902,6 +891,7 @@ KEY_USAGE_SPAKE_FACTOR                  66
             <c>&#8226;</c><c>Multiplier Conversion: <xref target="RFC8032"/> section 3.1</c>
             <c>&#8226;</c><c>SPAKE M Constant: d048032c6ea0b6d697ddc2e86bda85a33adac920f1bf18e1b0c6d166a5cecdaf</c>
             <c>&#8226;</c><c>SPAKE N Constant: d3bfb518f44f3430f29d0c92af503865a1ed3281dc69b35dd868ba85f886c4ab</c>
+            <c>&#8226;</c><c>Hash function: SHA-256 (<xref target="RFC6234"/>)</c>
           </texttable>
 
           <texttable style="none" align="left">
@@ -914,6 +904,7 @@ KEY_USAGE_SPAKE_FACTOR                  66
             <c>&#8226;</c><c>Multiplier Conversion: <xref target="SEC1"/> section 2.3.8.</c>
             <c>&#8226;</c><c>SPAKE M Constant: 02886e2f97ace46e55ba9dd7242579f2993b64e16ef3dcab95afd497333d8fa12f</c>
             <c>&#8226;</c><c>SPAKE N Constant: 03d8bbd6c639c62937b04d997f38c3770719c629d7014d49a24b4f98baa1292b49</c>
+            <c>&#8226;</c><c>Hash function: SHA-256 (<xref target="RFC6234"/>)</c>
           </texttable>
 
           <texttable style="none" align="left">
@@ -930,6 +921,7 @@ KEY_USAGE_SPAKE_FACTOR                  66
             <c>&#8226;</c><c>SPAKE N Constant:
             02c72cf2e390853a1c1c4ad816a62fd15824f56078918f43f922ca215
             18f9c543bb252c5490214cf9aa3f0baab4b665c10</c>
+            <c>&#8226;</c><c>Hash function: SHA-384 (<xref target="RFC6234"/>)</c>
           </texttable>
 
           <texttable style="none" align="left">
@@ -948,6 +940,7 @@ KEY_USAGE_SPAKE_FACTOR                  66
             0200c7924b9ec017f3094562894336a53c50167ba8c5963876880542b
             c669e494b2532d76c5b53dfb349fdf69154b9e0048c58a42e8ed04cef052a3bc34
             9d95575cd25</c>
+            <c>&#8226;</c><c>Hash function: SHA-512 (<xref target="RFC6234"/>)</c>
           </texttable>
         </section>
       </section>
@@ -963,6 +956,7 @@ KEY_USAGE_SPAKE_FACTOR                  66
       &rfc4120;
       &rfc5226;
       &rfc6113;
+      &rfc6234;
       &rfc7748;
       &rfc8032;
       &spake;
@@ -987,7 +981,6 @@ KEY_USAGE_SPAKE_FACTOR                  66
     </references>
     <references title='Non-normative References'>
       &rfc6560;
-      &rfc6649;
       <reference anchor="SPAKE">
         <front>
           <title>Simple Password-Based Encrypted Key Exchange Protocols</title>
@@ -1083,7 +1076,10 @@ END
         <artwork><![CDATA[
 DES3 edwards25519
 key: 850bb51358548cd05e86768c313e3bfef7511937dcf72c3e
-w: a1f1a25cbd8e3092667e2fddba8ecd24f2c9cef124f7a3371ae81e11cad42a07
+w (PRF+ output): 686d84730cb8679ae95416c6567c6a63
+                 f2c9cef124f7a3371ae81e11cad42a37
+w (reduced multiplier): a1f1a25cbd8e3092667e2fddba8ecd24
+                        f2c9cef124f7a3371ae81e11cad42a07
 x: 201012d07bfd48ddfa33c4aac4fb1e229fb0d043cfe65ebfb14399091c71a723
 y: 500b294797b8b042aca1bedc0f5931a4f52c537b3608b2d05cc8a2372f439f25
 X: ec274df1920dc0f690c8741b794127233745444161016ef950ad75c51db58c3e
@@ -1092,26 +1088,29 @@ T: 18f511e750c97b592acd30db7d9e5fca660389102e6bf610c1bfbed4616c8362
 S: 5d10705e0d1e43d5dbf30240ccfbde4a0230c70d4c79147ab0b317edad2f8ae7
 K: 25bde0d875f0feb5755f45ba5e857889d916ecf7476f116aa31dc3e037ec4292
 SPAKESupport: a0093007a0053003020101
-Checksum after SPAKESupport: 9037756a58a060f80c13354b1a743a66837f1d4d
 SPAKEChallenge: a1363034a003020101a122042018f511e750c97b592acd30
                 db7d9e5fca660389102e6bf610c1bfbed4616c8362a20930
                 073005a003020101
-Checksum after SPAKEChallenge: 145fbe58e8bd6bf84627
-                               df10ee9954b7849fdc8c
-Final checksum after pubkey: f08091064aa5cc32c5660d9a04efb84a1948381b
+Transcript hash after challenge: 22bb2271e34d329d52073c70b1d11879
+                                 73181f0bc7614266bb79ee80d3335175
+Final transcript hash after pubkey: eaaa08807d0616026ff51c849efbf35b
+                                    a0ce3c5300e7d486da46351b13d4605b
 KDC-REQ-BODY: 3075a00703050000000000a1143012a003020101a10b3009
               1b077261656275726ea2101b0e415448454e412e4d49542e
               454455a3233021a003020102a11a30181b066b7262746774
               1b0e415448454e412e4d49542e454455a511180f31393730
               303130313030303030305aa703020100a8053003020110
-K'[0]: 8fcdad5da81f0b4962e91a67d598a2d9c84fc83b0104c868
-K'[1]: abf286ce894523013ba89e3413f7c4ef43c1eca8efa7dadf
-K'[2]: 6897524c86b5dc5ec7ecc1944cbc1aae7cbcc1643dcd989e
-K'[3]: b0a22c32e37902e023192cefada1869b08e69429e9fe0243
+K'[0]: baf12fae7cd958cbf1a29bfbc71f89ce49e03e295d89dafd
+K'[1]: 64f73dd9c41908206bcec1f719026b574f9d13463d7a2520
+K'[2]: 0454520b086b152c455829e6baeff78a61dfe9e3d04a895d
+K'[3]: 4a92260b25e3ef94c125d5c24c3e5bced5b37976e67f25c4
 
 RC4 edwards25519
 key: 8846f7eaee8fb117ad06bdd830b7586c
-w: 2713c1583c53861520b849bfef0525cd4fe82215b3ea6fcd896561d48048f40c
+w (PRF+ output): 7c86659d29cf2b2ea93bfe79c3cefb88
+                 50e82215b3ea6fcd896561d48048f49c
+w (reduced multiplier): 2713c1583c53861520b849bfef0525cd
+                        4fe82215b3ea6fcd896561d48048f40c
 x: c8a62e7b626f44cad807b2d695450697e020d230a738c5cd5691cc781dce8754
 y: 18fe7c1512708c7fd06db270361f04593775bc634ceaf45347e5c11c38aae017
 X: b0bcbbdd25aa031f4608d0442dd4924be7731d49c089a8301859d77343ffb567
@@ -1120,25 +1119,29 @@ T: 7db465f1c08c64983a19f560bce966fe5306c4b447f70a5bca14612a92da1d63
 S: 38f8d4568090148ebc9fd17c241b4cc2769505a7ca6f3f7104417b72b5b5cf54
 K: 03e75edd2cd7e7677642dd68736e91700953ac55dc650e3c2a1b3b4acdb800f8
 SPAKESupport: a0093007a0053003020101
-Checksum after SPAKESupport: c8bb7fb72f6b142557fd5de9b1b8bb4c
 SPAKEChallenge: a1363034a003020101a12204207db465f1c08c64983a19f5
                 60bce966fe5306c4b447f70a5bca14612a92da1d63a20930
                 073005a003020101
-Checksum after SPAKEChallenge: 318afd9874400fffa744bc602615cde8
-Final checksum after pubkey: 0853678dff8b9e5eb855c5e05420790c
+Transcript hash after challenge: 3cde9ed9b562a09d816885b6c225f733
+                                 6d9e2674bb4df903dfc894d963a2af42
+Final transcript hash after pubkey: f4b208458017de6ef7f6a307d47d87db
+                                    6c2af1d291b726860f68bc08bfef440a
 KDC-REQ-BODY: 3075a00703050000000000a1143012a003020101a10b3009
               1b077261656275726ea2101b0e415448454e412e4d49542e
               454455a3233021a003020102a11a30181b066b7262746774
               1b0e415448454e412e4d49542e454455a511180f31393730
               303130313030303030305aa703020100a8053003020117
-K'[0]: 87a50a15f0dbd7c958e5bf1bbffee4f2
-K'[1]: 1b4a484d4ac7dd18acf5ebc42d8e1b14
-K'[2]: 8d6b89f491be1b532be6c6e8482328fe
-K'[3]: 425c47073edd4a6f0067f08166d44c7a
+K'[0]: 770b720c82384cbb693e85411eedecba
+K'[1]: 621deec88e2865837c4d3462bb50a1d5
+K'[2]: 1cc8f6333b9fa3b42662fd9914fbd5bb
+K'[3]: edb4032b7fc3806d5211a534dcbc390c
 
 AES128 edwards25519
 key: fca822951813fb252154c883f5ee1cf4
-w: 17c2a9030afb7c37839bd4ae7fdfeb179e99e710e464e62f1fb7c9b67936f30b
+w (PRF+ output): 0d591b197b667e083c2f5f98ac891d3c
+                 9f99e710e464e62f1fb7c9b67936f3eb
+w (reduced multiplier): 17c2a9030afb7c37839bd4ae7fdfeb17
+                        9e99e710e464e62f1fb7c9b67936f30b
 x: 50be049a5a570fa1459fb9f666e6fd80602e4e87790a0e567f12438a2c96c138
 y: b877afe8612b406d96be85bd9f19d423e95be96c0e1e0b5824127195c3ed5917
 X: e73a443c678913eb4a0cad5cbd3086cf82f65a5a91b611e01e949f5c52efd6dd
@@ -1147,25 +1150,29 @@ T: 9e9311d985c1355e022d7c3c694ad8d6f7ad6d647b68a90b0fe46992818002da
 S: fbe08f7f96cd5d4139e7c9eccb95e79b8ace41e270a60198c007df18525b628e
 K: c2f7f99997c585e6b686ceb62db42f17cc70932def3bb4cf009e36f22ea5473d
 SPAKESupport: a0093007a0053003020101
-Checksum after SPAKESupport: ce5052873534f00424e38897
 SPAKEChallenge: a1363034a003020101a12204209e9311d985c1355e022d7c
                 3c694ad8d6f7ad6d647b68a90b0fe46992818002daa20930
                 073005a003020101
-Checksum after SPAKEChallenge: 9c46dbbaa67fe262585e68f4
-Final checksum after pubkey: 9eb1f4db71208adad0d6d9f1
+Transcript hash after challenge: 4512310282c01b39dd9aebd0cc2a5e53
+                                 2ed077a6c11d4c973c4593d525078797
+Final transcript hash after pubkey: 951285f107c87f0169b9c918a1f51f60
+                                    cb1a75b9f8bb799a99f53d03add94b5f
 KDC-REQ-BODY: 3075a00703050000000000a1143012a003020101a10b3009
               1b077261656275726ea2101b0e415448454e412e4d49542e
               454455a3233021a003020102a11a30181b066b7262746774
               1b0e415448454e412e4d49542e454455a511180f31393730
               303130313030303030305aa703020100a8053003020111
-K'[0]: 50de22f3b9cd6cd283b23396870ca246
-K'[1]: b8e433cef3a84fff59f683b5206d3c86
-K'[2]: 3c96a2da9575a297c4e831fe2ae625d8
-K'[3]: 54ef2f63b25f66aed65f3d6c77030c6a
+K'[0]: 548022d58a7c47eae8c49dccf6baa407
+K'[1]: b2c9ba0e13fc8ab3a9d96b51b601cf4a
+K'[2]: 69f0ee5fdb6c237e7fcd38d9f87df1bd
+K'[3]: 78f91e2240b5ee528a5cc8d7cbebfba5
 
 AES256 edwards25519
 key: 01b897121d933ab44b47eb5494db15e50eb74530dbdae9b634d65020ff5d88c1
-w: 35b35ca126156b5bf4ec8b90e9545060f2108f1b6aa97b381012b9400c9e3f0e
+w (PRF+ output): e902341590a1b4bb4d606a1c643cccb3
+                 f2108f1b6aa97b381012b9400c9e3f4e
+w (reduced multiplier): 35b35ca126156b5bf4ec8b90e9545060
+                        f2108f1b6aa97b381012b9400c9e3f0e
 x: 88c6c0a4f0241ef217c9788f02c32d00b72e4310748cd8fb5f94717607e6417d
 y: 88b859df58ef5c69bacdfe681c582754eaab09a74dc29cff50b328613c232f55
 X: 23c48eaff2721051946313840723b38f563c59b92043d6ffd752f95781af0327
@@ -1174,29 +1181,33 @@ T: 6f301aacae1220e91be42868c163c5009aeea1e9d9e28afcfc339cda5e7105b5
 S: 9e2cc32908fc46273279ec75354b4aeafa70c3d99a4d507175ed70d80b255dda
 K: cf57f58f6e60169d2ecc8f20bb923a8e4c16e5bc95b9e64b5dc870da7026321b
 SPAKESupport: a0093007a0053003020101
-Checksum after SPAKESupport: 14b16e16da078fab9830a66c
 SPAKEChallenge: a1363034a003020101a12204206f301aacae1220e91be428
                 68c163c5009aeea1e9d9e28afcfc339cda5e7105b5a20930
                 073005a003020101
-Checksum after SPAKEChallenge: 667e82727168d0fef248c926
-Final checksum after pubkey: 32bf15d0606762b6411a0f68
+Transcript hash after challenge: 23a5e72eb4dedd1ca860f43736c458f0
+                                 775c3bb1370a26af8a9374d521d70ec9
+Final transcript hash after pubkey: 1c605649d4658b58cbe79a5faf227acc
+                                    16c355c58b7dade022f90c158fe5ed8e
 KDC-REQ-BODY: 3075a00703050000000000a1143012a003020101a10b3009
               1b077261656275726ea2101b0e415448454e412e4d49542e
               454455a3233021a003020102a11a30181b066b7262746774
               1b0e415448454e412e4d49542e454455a511180f31393730
               303130313030303030305aa703020100a8053003020112
-K'[0]: 9463038f091c0aed6f8186224b7da5cf
-       24557bf5c7fd6fe35526ce34a9eb5b05
-K'[1]: 1900e226176d6730e9e4c1bf342fd954
-       df3fc65790f8c267c89b4a3026d0d164
-K'[2]: b025fb4103dc29f233640540627331e1
-       b567c1a7f5a3a00d800c70f0ef213804
-K'[3]: 840e2280e4d4c61c44c057e2c7c92207
-       041dd205bd76b6dc50c9add16cc76c7b
+K'[0]: a9bfa71c95c575756f922871524b6528
+       8b3f695573ccc0633e87449568210c23
+K'[1]: 1865a9ee1ef0640ec28ac007391cac62
+       4c42639c714767a974e99aa10003015f
+K'[2]: e57781513fefdb978e374e156b0da0c1
+       a08148f5eb26b8e157ac3c077e28bf49
+K'[3]: 008e6487293c3cc9fabbbcdd8b392d6d
+       cb88222317fd7fe52d12fbc44fa047f1
 
 AES256 P-256
 key: 01b897121d933ab44b47eb5494db15e50eb74530dbdae9b634d65020ff5d88c1
-w: eb2984af18703f94dd5288b8596cd36988d0d4e83bfb2b44de14d0e95e2090bd
+w (PRF+ output): eb2984af18703f94dd5288b8596cd369
+                 88d0d4e83bfb2b44de14d0e95e2090bd
+w (reduced multiplier): eb2984af18703f94dd5288b8596cd369
+                        88d0d4e83bfb2b44de14d0e95e2090bd
 x: 935ddd725129fb7c6288e1a5cc45782198a6416d1775336d71eacd0549a3e80e
 y: e07405eb215663abc1f254b8adc0da7a16febaa011af923d79fdef7c42930b33
 X: 03bc802165aea7dbd98cc155056249fe0a37a9c203a7c0f7e872d5bf687bd105e2
@@ -1205,30 +1216,34 @@ T: 024f62078ceb53840d02612195494d0d0d88de21feeb81187c71cbf3d01e71788d
 S: 021d07dc31266fc7cfd904ce2632111a169b7ec730e5f74a7e79700f86638e13c8
 K: 0268489d7a9983f2fde69c6e6a1307e9d252259264f5f2dfc32f58cca19671e79b
 SPAKESupport: a0093007a0053003020102
-Checksum after SPAKESupport: 61f93e7f998dec5f54cac55c
 SPAKEChallenge: a1373035a003020102a1230421024f62078ceb53840d0261
                 2195494d0d0d88de21feeb81187c71cbf3d01e71788da209
                 30073005a003020101
-Checksum after SPAKEChallenge: 949916036d3c524608533206
-Final checksum after pubkey: 1024bfe60a1e22b5bf2838c3
+Transcript hash after challenge: 0a142afca77c2e92b066572a90389eac
+                                 40a6b1f1ed8b534d342591c0e7727e00
+Final transcript hash after pubkey: 20ad3c1a9a90fc037d1963a1c4bfb15a
+                                    b4484d7b6cf07b12d24984f14652de60
 KDC-REQ-BODY: 3075a00703050000000000a1143012a003020101a10b3009
               1b077261656275726ea2101b0e415448454e412e4d49542e
               454455a3233021a003020102a11a30181b066b7262746774
               1b0e415448454e412e4d49542e454455a511180f31393730
               303130313030303030305aa703020100a8053003020112
-K'[0]: b3a882eccd2f31df46880f6235522a4d
-       87523a34442547778c46780f5b35800a
-K'[1]: 6e18ebfd20a9a05af11b320eaab15870
-       93f3e21a5efcb261307786661330344d
-K'[2]: 11e1a36e87c729a89bbda12cfa15652f
-       a1848c0ba9b72cb3e69562648744fb09
-K'[3]: 9875d491c6d0bb7cbe6d374c368e1242
-       97e506becbf8ec6aa539a0d70b9e430a
+K'[0]: 7d3b906f7be49932db22cd3463f032d0
+       6c9c078be4b1d076d201fc6e61ef531e
+K'[1]: 17d74e36f8993841fbb7feb12fa4f011
+       243d3ae4d2ace55b39379294bbc4db2c
+K'[2]: d192c9044081a2aa6a97a6c69e2724e8
+       e5671c2c9ce073dd439cdbaf96d7dab0
+K'[3]: 41e5bad6b67f12c53ce0e2720dd6a988
+       7f877bf9463c2d5209c74c36f8d776b7
 
 AES256 P-384
 key: 01b897121d933ab44b47eb5494db15e50eb74530dbdae9b634d65020ff5d88c1
-w: 0304cfc55151c6bbe889653db96dbfe0ba4acafc024c1e8840cb3a486f6d80c1
-   6e1b8974016aa4b7fa43042a9b3825b1
+w (PRF+ output): 0304cfc55151c6bbe889653db96dbfe0ba4acafc024c1e88
+                 40cb3a486f6d80c16e1b8974016aa4b7fa43042a9b3825b1
+w (reduced multiplier): 0304cfc55151c6bbe889653db96dbfe0
+                        ba4acafc024c1e8840cb3a486f6d80c1
+                        6e1b8974016aa4b7fa43042a9b3825b1
 x: f323ca74d344749096fd35d0adf20806e521460637176e84d977e9933c49d76f
    cfc6e62585940927468ff53d864a7a50
 y: 5b7c709acb175a5afb82860deabca8d0b341facdff0ac0f1a425799aa905d750
@@ -1244,31 +1259,40 @@ S: 020d5adfdb92bc377041cf5837412574c5d13e0f4739208a4f0c859a0a302bc6
 K: 0264aa8c61da9600dfb0beb5e46550d63740e4ef29e73f1a30d543eb43c25499
    037ad16538586552761b093cf0e37c703a
 SPAKESupport: a0093007a0053003020103
-Checksum after SPAKESupport: a0024c7b5ff667ae074a9988
 SPAKEChallenge: a1473045a003020103a133043102a1524603ef14f184696f
                 854229d3397507a66c63f841ba748451056be07879ac2989
-                12387b1c5cdff6381c264701be57a20930073005a003020101
-Checksum after SPAKEChallenge: ecd0f64ed7c0d4e18fa4c5b4
-Final checksum after pubkey: a238108c88afd856f04d3aa5
+                12387b1c5cdff6381c264701be57a20930073005a0030201
+                01
+Transcript hash after challenge: 4d4095d9f94552e15015881a3f2cf458
+                                 1be83217cf7ad830d2f051dba3ec8caa
+                                 6e354eaa85738d7035317ac557f8c294
+Final transcript hash after pubkey: 5ac0d99ef9e5a73998797fe64f074673
+                                    e3952dec4c7d1aacce8b75f64d2b0276
+                                    a901cb8539b4e8ed69e4db0ce805b47b
 KDC-REQ-BODY: 3075a00703050000000000a1143012a003020101a10b3009
               1b077261656275726ea2101b0e415448454e412e4d49542e
               454455a3233021a003020102a11a30181b066b7262746774
               1b0e415448454e412e4d49542e454455a511180f31393730
               303130313030303030305aa703020100a8053003020112
-K'[0]: ff59fb5fb83c7bafe197b62c853eb7c3
-       a2902301dfe8326851626a0e9c714c47
-K'[1]: e3c741ac7041feed0f0b5c36cb74c179
-       cb565e509b6d65594d0badafe318c4dc
-K'[2]: 9c7a73087f22b52db38a14eb8292df61
-       54516eaadb7149b14d35864bdb85aa22
-K'[3]: 75ea14f0f53ee8dbabd78f446462cfda
-       590d4ace0fa93708a00f26f26c565e56
+K'[0]: b917d37c16dd1d8567fbe379f64e1ee3
+       6ca3fd127aa4e60f97e4afa3d9e56d91
+K'[1]: 93d40079dab229b9c79366829f4e7e72
+       82e6a4b943ac7bac69922d516673f49a
+K'[2]: bfc4f16f12f683e71589f9a888e23287
+       5ef293ac9793db6c919567cd7b94bcd4
+K'[3]: 3630e2b5b99938e7506733141e8ec344
+       166f6407e5fc2ef107c156e764d1bc20
 
 AES256 P-521
 key: 01b897121d933ab44b47eb5494db15e50eb74530dbdae9b634d65020ff5d88c1
-w: 003a095a2b2386eff3eb15b735398da1caf95bc8425665d82370aff58b0471f3
-   4cce63791cfed967f0c94c16054b3e1703133681bece1e05219f5426bc944b0f
-   bfb3
+w (PRF+ output): de3a095a2b2386eff3eb15b735398da1caf95bc8425665d8
+                 2370aff58b0471f34a57bccddf1ebf0a2965b58a93ee5b45
+                 e85d1a5435d1c8c83662999722d542831f9a
+w (reduced multiplier): 003a095a2b2386eff3eb15b735398da1
+                        caf95bc8425665d82370aff58b0471f3
+                        4cce63791cfed967f0c94c16054b3e17
+                        03133681bece1e05219f5426bc944b0f
+                        bfb3
 x: 017c38701a14b490b6081dfc83524562be7fbb42e0b20426465e3e37952d30bc
    ab0ed857010255d44936a1515607964a870c7c879b741d878f9f9cdf5a865306
    f3f5
@@ -1291,30 +1315,38 @@ K: 03007c303f62f09282cc849490805bd4457a6793a832cbeb55df427db6a31e99
    b055d5dc99756d24d47b70ad8b6015b0fb8742a718462ed423b90fa3fe631ac1
    3fa916
 SPAKESupport: a0093007a0053003020104
-Checksum after SPAKESupport: 1b69d116036e141e45d4f7d7
 SPAKEChallenge: a1593057a003020104a145044302017d3de19a3ec53d0174
                 905665ef37947d142535102cd9809c0dfbd0dfe007353d54
                 cf406ce2a59950f2bb540df6fbe75f8bbbef811c9ba06cc2
                 75adbd96756696eca20930073005a003020101
-Checksum after SPAKEChallenge: cac3da1e9ab1261723ece823
-Final checksum after pubkey: 654493ca7e47f3c5200f4b84
+Transcript hash after challenge: 554405860f8a80944228f1fa2466411d
+                                 cf236162aa385e1289131b39e1fd59f2
+                                 5e58b4c281ff059c28dc20f5803b87c6
+                                 7571ce64cea01b39a21819d1ef1cdc7f
+Final transcript hash after pubkey: 8d6a89ae4d80cc4e47b6f4e48ea3e579
+                                    19cc69598d0d3dc7c8bd49b6f1db1409
+                                    ca0312944cd964e213aba98537041102
+                                    237cff5b331e5347a0673869b412302e
 KDC-REQ-BODY: 3075a00703050000000000a1143012a003020101a10b3009
               1b077261656275726ea2101b0e415448454e412e4d49542e
               454455a3233021a003020102a11a30181b066b7262746774
               1b0e415448454e412e4d49542e454455a511180f31393730
               303130313030303030305aa703020100a8053003020112
-K'[0]: c91635dfd1de3884b635b58b30d3cfd5
-       26fe78f8dade6f19e4eb2fb23ef594ca
-K'[1]: 03d38e139bb3f66cc76c5da720f3bf11
-       4280f64ed708e69e96094bb62aa28f32
-K'[2]: 515eaa3c45b08bc9d77468059e64a8e1
-       96cfcd15db92ad431cae5edbe721d07e
-K'[3]: 898ae786e58391d8a00eb7a7cbddd005
-       3aff9147b42a3076d934608e70a6f0ff
+K'[0]: 1eb3d10bee8fab483adcd3eb38f3ebf1
+       f4feb8db96ecc035f563cf2e1115d276
+K'[1]: 482b92781ce57f49176e4c94153cc622
+       fe247a7dbe931d1478315f856f085890
+K'[2]: a2c215126dd3df280aab5a27e1e0fb7e
+       594192cbff8d6d8e1b6f1818d9bb8fac
+K'[3]: cc06603de984324013a01f888de6d43b
+       410a4da2dea53509f30e433c352fb668
 
 AES256 edwards25519 with accepted optimistic challenge
 key: 01b897121d933ab44b47eb5494db15e50eb74530dbdae9b634d65020ff5d88c1
-w: 35b35ca126156b5bf4ec8b90e9545060f2108f1b6aa97b381012b9400c9e3f0e
+w (PRF+ output): e902341590a1b4bb4d606a1c643cccb3
+                 f2108f1b6aa97b381012b9400c9e3f4e
+w (reduced multiplier): 35b35ca126156b5bf4ec8b90e9545060
+                        f2108f1b6aa97b381012b9400c9e3f0e
 x: 70937207344cafbc53c8a55070e399c584cbafce00b836980dd4e7e74fad2a64
 y: 785d6801a2490df028903ac6449b105f2ff0db895b252953cdc2076649526103
 X: 13841224ea50438c1d9457159d05f2b7cd9d05daf154888eeed223e79008b47c
@@ -1325,27 +1357,34 @@ K: d3c5e4266aa6d1b2873a97ce8af91c7e4d7a7ac456acced7908d34c561ad8fa6
 SPAKEChallenge: a1363034a003020101a122042083523b35f1565006cbfc4f
                 159885467c2fb9bc6fe23d36cb1da43d199f1a3118a20930
                 073005a003020101
-Checksum after SPAKEChallenge: 0b1dc2059f7411b639295982
-Final checksum after pubkey: 3990d78eb0abc055d1f69fcb
+Transcript hash after challenge: 0332da8ba3095ccd127c51740cb905ba
+                                 c76e90725e769570b9d8338e6d62a7f2
+Final transcript hash after pubkey: 26f07f9f8965307434d11ea855461d41
+                                    e0cbabcc0a1bab48ecee0c6c1a4292b7
 KDC-REQ-BODY: 3075a00703050000000000a1143012a003020101a10b3009
               1b077261656275726ea2101b0e415448454e412e4d49542e
               454455a3233021a003020102a11a30181b066b7262746774
               1b0e415448454e412e4d49542e454455a511180f31393730
               303130313030303030305aa703020100a8053003020112
-K'[0]: 1e9b04bdbdaaffb340aa09c6cdf560fa
-       dcaadb7cb8762b22cd6e7c96753090b7
-K'[1]: 7b959d40bd6c517a89278b008cf314e5
-       d947b181a3251d2832ab61a21c40d484
-K'[2]: 3e484bb86ab7f4ffc4b80a6f6d79692c
-       55daf2b78654b38c7f1d37b1d688d1f3
-K'[3]: 23a331ddf33211859b82502295b0be4b
-       23a56057b77356d62a13985ca573dae1
+K'[0]: 4569ec08b5de5c3cc19d941725913ace
+       8d74524b521a341dc746acd5c3784d92
+K'[1]: 0d96ce1a4ac0f2e280a0cfc31742b064
+       61d83d04ae45433db2d80478dd882a4c
+K'[2]: 58018c19315a1ba5d5bb9813b58029f0
+       aec18a6f9ca59e0847de1c60bc25945c
+K'[3]: ed7e9bffd68c54d86fb19cd3c03f317f
+       88a71ad9a5e94c28581d93fc4ec72b6a
 
 AES256 P-521 with rejected optimistic edwards25519 challenge
 key: 01b897121d933ab44b47eb5494db15e50eb74530dbdae9b634d65020ff5d88c1
-w: 003a095a2b2386eff3eb15b735398da1caf95bc8425665d82370aff58b0471f3
-   4cce63791cfed967f0c94c16054b3e1703133681bece1e05219f5426bc944b0f
-   bfb3
+w (PRF+ output): de3a095a2b2386eff3eb15b735398da1caf95bc8425665d8
+                 2370aff58b0471f34a57bccddf1ebf0a2965b58a93ee5b45
+                 e85d1a5435d1c8c83662999722d542831f9a
+w (reduced multiplier): 003a095a2b2386eff3eb15b735398da1
+                        caf95bc8425665d82370aff58b0471f3
+                        4cce63791cfed967f0c94c16054b3e17
+                        03133681bece1e05219f5426bc944b0f
+                        bfb3
 x: 01687b59051bf40048d7c31d5a973d792fa12284b7a447e7f5938b5885ca0bb2
    c3f0bd30291a55fea08e143e2e04bdd7d19b753c7c99032f06cab0d9c2aa8f83
    7ef7
@@ -1371,29 +1410,77 @@ Optimistic SPAKEChallenge: a1363034a003020102a122042047ca8c
                            24c3a4a70b6eca228322529dadcfa85c
                            f58faceecf5d5c02907b9e2deba20930
                            073005a003020101
-Checksum after optimist SPAKEChallenge: 57eff4df899bc520010deb48
 SPAKESupport: a0093007a0053003020104
-Checksum after SPAKESupport: c2fe6c3c142c207d0bdbdd9c
 SPAKEChallenge: a1593057a003020104a145044302014cb2e5b592ece5990f
                 0ef30d308c061de1598bc4272b4a6599bed466fd15216936
                 42abcf4dbe36ce1a2d13967de45f6c4f8d0fa8e14428bf03
                 fb96ef5f1ed3e645a20930073005a003020101
-Checksum after SPAKEChallenge: c78a00b2d896b73dbed4969b
-Final checksum after pubkey: 80a1da254a44641e0223a944
+Transcript hash after challenge: cb925b8baeae5e2867ab5b10ae1c941c
+                                 4ff4b58a4812c1f7bd1c862ad480a8e1
+                                 c6fcd5e88d846a2045e385841c91a75a
+                                 d2035f0ff692717608e2a5a90842eff2
+Final transcript hash after pubkey: d0efed5e3e2c39c26034756d92a66fec
+                                    3082ad793d0197f3f89ad36026f146a3
+                                    996e548aa3fc49e2e82f8cac5d132c50
+                                    5aa475b39e7be79cded22c26c41aa777
 KDC-REQ-BODY: 3075a00703050000000000a1143012a003020101a10b3009
               1b077261656275726ea2101b0e415448454e412e4d49542e
               454455a3233021a003020102a11a30181b066b7262746774
               1b0e415448454e412e4d49542e454455a511180f31393730
               303130313030303030305aa703020100a8053003020112
-K'[0]: 567cb2ee046cc10cd29cd5bbe5998e5c
-       d4fca318075981087400c32c55299697
-K'[1]: 57535deb12a3bcaac8389957d9065ee5
-       51a869148de1f457b232e12055ee9efa
-K'[2]: 6d18f714b69242f1e556b2819f895926
-       9ee0da5b014785b4f1fabb3b7318b70c
-K'[3]: a1d86d7d091800f191884e501974fa32
-       ca513a520197866d7c57e5c1296319e6
+K'[0]: 631fcc8596e7f40e59045950d72aa0b7
+       bac2810a07b767050e983841cf3a2d4c
+K'[1]: 881464920117074dbc67155a8f3341d1
+       121ef65f78ea0380bfa81a134c1c47b1
+K'[2]: 377b72ac3af2caad582d73ae4682fd56
+       b531ee56706200dd6c38c42b8219837a
+K'[3]: 35ad8e4d580ed3f0d15ad928329773c0
+       81bd19f9a56363f3a5f77c7e66108c26
 ]]></artwork>
+      </figure>
+      <t>There are currently no encryption types with a seed size large enough
+      to require multiple hash blocks during key derivation with any of the
+      assigned hash functions. To exercise this possibility, the following
+      test vector illustrates what keys would be derived if there were a copy
+      of the edwards25519 group with group number -1 and associated hash
+      function SHA-1:</t>
+      <figure>
+        <artwork><![CDATA[
+AES256 edwards25519 SHA-1 group number -1
+key: 01b897121d933ab44b47eb5494db15e50eb74530dbdae9b634d65020ff5d88c1
+w (PRF+ output): 26da6b118cee6fa5ea795ed32d61490d
+                 82b2f11102312f3f2fc04fb01c93df91
+w (reduced multiplier): d166c7cc9e72ca8c61f6a9185a987251
+                        81b2f11102312f3f2fc04fb01c93df01
+x: 606c1b668008ed78fe2eee942e8f08007f3f1dcbef66d37fd69033525bda2030
+y: 10fc4e0bb1a902e58f632a1ea0bceb366360ac985f46996d956a02572bfcf050
+X: 389621509665abad35eaab26eab3a0f593c7b4380562aa5513c1140fd78ce048
+Y: de3ed05986eeac518958b566f9bad065b321402025cd188f3d198dc55c6d6b8d
+T: 2289a4f3c613e6e1df95e94aaa3c127dc062b9fceec3f9b62378dc729d61d0e3
+S: f9a7fa352930dedb422d567700bfcd39ba221e7f9ac3e6b36f2b63b68b88642c
+K: 6f61d6b18323b6c3ddaac7c56712845335384f095d3e116f69feb926a04f1340
+SPAKESupport: a0093007a00530030201ff
+SPAKEChallenge: a1363034a0030201ffa12204202289a4f3c613e6e1df95e9
+                4aaa3c127dc062b9fceec3f9b62378dc729d61d0e3a20930
+                073005a003020101
+Transcript hash after challenge: f5c051eb75290f92142c
+                                 bbe80557ec2c85902c94
+Final transcript hash after pubkey: 9e26a3b148400c8f9cb8
+                                    545331e4e7dcab399cc0
+KDC-REQ-BODY: 3075a00703050000000000a1143012a003020101a10b3009
+              1b077261656275726ea2101b0e415448454e412e4d49542e
+              454455a3233021a003020102a11a30181b066b7262746774
+              1b0e415448454e412e4d49542e454455a511180f31393730
+              303130313030303030305aa703020100a8053003020112
+K'[0]: 40bceb51bba474fd29ae65950022b704
+       17b80d973fa8d8d6cd39833ff89964ad
+K'[1]: c29a7315453dc1cce938fa12a9e5c0db
+       2894b2194da14c9cd4f7bc3a6a37223d
+K'[2]: f261984dba3c230fad99d324f871514e
+       5aad670e44f00daef3264870b0851c25
+K'[3]: d24b2b46bab7c4d1790017d9116a7eeb
+       ca88b0562a5ad8989c826cb7dab715c7
+       ]]></artwork>
       </figure>
     </section>
 


### PR DESCRIPTION
For each group, define an associated hash function. Use it for
transcript hashing and key derivation. Since the hash depends on the
group, update the transcript hash with the support and challenge
messages concatenated together, and don't include a rejected
optimistic challenge in the transcript. Update test vectors
accordingly. As the PRF+ output is now used in the key derivation
hash, include it in the test vectors along with the encoded reduced
multiplier.

Since we are no longer computing checksums, drop down to one assigned
key usage number, named just KEY_USAGE_SPAKE.

Also, group and enctype numbers are signed, so specify two's
complement rather than unsigned when encoding them in four-byte
binary.
